### PR TITLE
which modules.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This module allows Logspout to send Docker logs in the GELF format to Graylog via UDP.
 
 ## Build
-To build, you'll need to fork [Logspout](https://github.com/gliderlabs/logspout), add the following code to `modules.go` 
+To build, you'll need to fork [Logspout](https://github.com/gliderlabs/logspout), add the following code to `custom/modules.go` 
 
 ```
 _ "github.com/micahhausler/logspout-gelf"


### PR DESCRIPTION
I found myself updating the /modules.go and getting a "module not found error" while building it.
Just clarify which module.go you should use to add this module for the build: custom/modules.go
